### PR TITLE
Revert "IOS-3384 Fixed incorrect public key for some Cosmos networks"

### DIFF
--- a/src/Cosmos/Signer.cpp
+++ b/src/Cosmos/Signer.cpp
@@ -16,7 +16,7 @@ namespace TW::Cosmos {
 
 Proto::SigningOutput Signer::sign(const Proto::SigningInput& input, TWCoinType coin) noexcept {
     const auto& privateKey = PrivateKey(input.private_key());
-    const auto& publicKey = privateKey.getPublicKey(TWPublicKeyTypeSECP256k1);
+    const auto& publicKey = privateKey.getPublicKey(TWCoinTypePublicKeyType(coin));
     return sign(input, coin, publicKey.bytes, nullptr);
 }
 


### PR DESCRIPTION
Reverts tangem/wallet-core#9