### PR TITLE
Add external signer support for jetton transactions

### DIFF
--- a/src/TheOpenNetwork/Signer.cpp
+++ b/src/TheOpenNetwork/Signer.cpp
@@ -35,6 +35,11 @@ Data Signer::createTransferMessage(std::shared_ptr<Wallet> wallet, const Private
 }
 
 Data Signer::createJettonTransferMessage(std::shared_ptr<Wallet> wallet, const PrivateKey& privateKey, const Proto::JettonTransfer& jettonTransfer) {
+    return createJettonTransferMessage(wallet, privateKey, jettonTransfer, nullptr);
+}
+
+// TANGEM
+Data Signer::createJettonTransferMessage(std::shared_ptr<Wallet> wallet, const PrivateKey& privateKey, const Proto::JettonTransfer& jettonTransfer, const std::function<Data(Data)> externalSigner) {
     const Proto::Transfer& transferData = jettonTransfer.transfer();
     
     const auto payload = jettonTransferPayload(
@@ -48,6 +53,7 @@ Data Signer::createJettonTransferMessage(std::shared_ptr<Wallet> wallet, const P
     
     const auto msg = wallet->createQueryMessage(
         privateKey,
+        externalSigner,
         Address(transferData.dest(), transferData.bounceable()),
         transferData.amount(),
         transferData.sequence_number(),
@@ -102,7 +108,7 @@ Proto::SigningOutput Signer::sign(const Proto::SigningInput& input, const Data& 
             case Proto::WalletVersion::WALLET_V4_R2: {
                 const int8_t workchainId = WorkchainType::Basechain;
                 auto wallet = std::make_shared<WalletV4R2>(publicKey, workchainId);
-                const auto& transferMessage = Signer::createJettonTransferMessage(wallet, privateKey, jettonTransfer);
+                const auto& transferMessage = Signer::createJettonTransferMessage(wallet, privateKey, jettonTransfer, externalSigner);
                 protoOutput.set_encoded(TW::Base64::encode(transferMessage));
                 break;
             }

--- a/src/TheOpenNetwork/Signer.h
+++ b/src/TheOpenNetwork/Signer.h
@@ -26,6 +26,9 @@ public:
 
     /// Creates a signed jetton transfer message
     static Data createJettonTransferMessage(std::shared_ptr<Wallet> wallet, const PrivateKey& privateKey, const Proto::JettonTransfer& transfer);
+    
+    // TANGEM
+    static Data createJettonTransferMessage(std::shared_ptr<Wallet> wallet, const PrivateKey& privateKey, const Proto::JettonTransfer& jettonTransfer, const std::function<Data(Data)> externalSigner);
 
     /// Signs a Proto::SigningInput transaction
     static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-tangem=4.0.21-tangem5
+tangem=4.0.21-tangem6


### PR DESCRIPTION
Пробросил externalSigner в функции трансфера токенов тона.